### PR TITLE
AOS-2149 Don't log errors from entire filter chain

### DIFF
--- a/src/main/java/no/skatteetaten/aurora/filter/logging/AuroraHeaderFilter.java
+++ b/src/main/java/no/skatteetaten/aurora/filter/logging/AuroraHeaderFilter.java
@@ -29,12 +29,8 @@ public class AuroraHeaderFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
         throws IOException, ServletException {
         try {
-            try {
-                copyHeadersFromRequestToMdc((HttpServletRequest) request, HEADERS);
-                assertKorrelasjonsIdIsSet();
-            } catch (Throwable t) {
-                LOG.error("Kunne ikke håndtere Aurora headere", t);
-            }
+            copyHeadersFromRequestToMdc((HttpServletRequest) request, HEADERS);
+            assertKorrelasjonsIdIsSet();
 
             chain.doFilter(request, response);
         } finally {

--- a/src/main/java/no/skatteetaten/aurora/filter/logging/AuroraHeaderFilter.java
+++ b/src/main/java/no/skatteetaten/aurora/filter/logging/AuroraHeaderFilter.java
@@ -29,12 +29,14 @@ public class AuroraHeaderFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
         throws IOException, ServletException {
         try {
-            copyHeadersFromRequestToMdc((HttpServletRequest) request, HEADERS);
-            assertKorrelasjonsIdIsSet();
+            try {
+                copyHeadersFromRequestToMdc((HttpServletRequest) request, HEADERS);
+                assertKorrelasjonsIdIsSet();
+            } catch (Throwable t) {
+                LOG.error("Kunne ikke håndtere Aurora headere", t);
+            }
 
             chain.doFilter(request, response);
-        } catch (Throwable t) {
-            LOG.error("Kunne ikke håndtere Aurora headere", t);
         } finally {
             MDC.remove(KORRELASJONS_ID);
             RequestKorrelasjon.cleanup();


### PR DESCRIPTION
Exceptions from `chain.doFilter(request, response);` are not related to Aurora headers, and thus should not be caught and logged in this filter.