### PR TITLE
Clear MDC

### DIFF
--- a/src/main/java/no/skatteetaten/aurora/filter/logging/AuroraHeaderFilter.java
+++ b/src/main/java/no/skatteetaten/aurora/filter/logging/AuroraHeaderFilter.java
@@ -58,6 +58,8 @@ public class AuroraHeaderFilter implements Filter {
             String headerValue = request.getHeader(headerName);
             if (headerValue != null && !headerValue.trim().isEmpty()) {
                 MDC.put(headerName, headerValue);
+            } else {
+                MDC.remove(headerName);
             }
         });
         LOG.debug("Registrerte headerverdier i MDC");


### PR DESCRIPTION
Ensure no old stale values are left on ThreadLocal if a sub sequent request does not contain all headers